### PR TITLE
Basic implementation of user photo selection

### DIFF
--- a/Instacard.xcodeproj/project.pbxproj
+++ b/Instacard.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0165ACA42914BF5B00B71C79 /* SelectedImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0165ACA32914BF5B00B71C79 /* SelectedImageModel.swift */; };
+		0165ACA62914C5DD00B71C79 /* SelectedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0165ACA52914C5DD00B71C79 /* SelectedImageView.swift */; };
 		4C1A99952912A23C00F3B71F /* InstacardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1A99942912A23C00F3B71F /* InstacardApp.swift */; };
 		4C1A99972912A23C00F3B71F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1A99962912A23C00F3B71F /* ContentView.swift */; };
 		4C1A99992912A23E00F3B71F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4C1A99982912A23E00F3B71F /* Assets.xcassets */; };
@@ -14,6 +16,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0165ACA32914BF5B00B71C79 /* SelectedImageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageModel.swift; sourceTree = "<group>"; };
+		0165ACA52914C5DD00B71C79 /* SelectedImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageView.swift; sourceTree = "<group>"; };
 		4C1A99912912A23C00F3B71F /* Instacard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Instacard.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C1A99942912A23C00F3B71F /* InstacardApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstacardApp.swift; sourceTree = "<group>"; };
 		4C1A99962912A23C00F3B71F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -55,6 +59,8 @@
 				4C1A99962912A23C00F3B71F /* ContentView.swift */,
 				4C1A99982912A23E00F3B71F /* Assets.xcassets */,
 				4C1A999A2912A23E00F3B71F /* Preview Content */,
+				0165ACA32914BF5B00B71C79 /* SelectedImageModel.swift */,
+				0165ACA52914C5DD00B71C79 /* SelectedImageView.swift */,
 			);
 			path = Instacard;
 			sourceTree = "<group>";
@@ -137,6 +143,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0165ACA62914C5DD00B71C79 /* SelectedImageView.swift in Sources */,
+				0165ACA42914BF5B00B71C79 /* SelectedImageModel.swift in Sources */,
 				4C1A99972912A23C00F3B71F /* ContentView.swift in Sources */,
 				4C1A99952912A23C00F3B71F /* InstacardApp.swift in Sources */,
 			);

--- a/Instacard/ContentView.swift
+++ b/Instacard/ContentView.swift
@@ -6,20 +6,19 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct ContentView: View {
+    @StateObject var viewModel = SelectedImageModel()
+    
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
+            SelectedImagePreview(selectedImageState: viewModel.selectedImageState)
             Text("Instacard!")
             Button("Take Image") {
                 // Open camera to take a picture.
             }
-            Button("Load Image") {
-                // Load an image from the album.
-            }
+            SelectImageFromAlbum(viewModel: viewModel)
             
         }
         .padding()

--- a/Instacard/SelectedImageModel.swift
+++ b/Instacard/SelectedImageModel.swift
@@ -1,0 +1,83 @@
+//
+//  ImageModel.swift
+//  Instacard
+//
+//  Created by Nick Kenyeres on 2022-11-03.
+//
+//  Adapted from Apple's sample code: Bringing Photos picker to your SwiftUI app
+//  see: https://developer.apple.com/documentation/photokit/bringing_photos_picker_to_your_swiftui_app
+//
+
+import SwiftUI
+import PhotosUI
+import CoreTransferable
+
+@MainActor
+class SelectedImageModel: ObservableObject {
+    enum SelectedImageState {
+        case empty
+        case loading(Progress)
+        case success(Image)
+        case failure(Error)
+    }
+    
+    enum TransferError: Error {
+        case importFailed
+    }
+    
+    struct SelectedImage: Transferable {
+        let image: Image
+        
+        static var transferRepresentation: some TransferRepresentation {
+            DataRepresentation(importedContentType: .image) { data in
+            #if canImport(AppKit)
+                guard let nsImage = NSImage(data: data) else {
+                    throw TransferError.importFailed
+                }
+                let image = Image(nsImage: nsImage)
+                return SelectedImage(image: image)
+            #elseif canImport(UIKit)
+                guard let uiImage = UIImage(data: data) else {
+                    throw TransferError.importFailed
+                }
+                let image = Image(uiImage: uiImage)
+                return SelectedImage(image: image)
+            #else
+                throw TransferError.importFailed
+            #endif
+            }
+        }
+    }
+    
+    @Published private(set) var selectedImageState: SelectedImageState = .empty
+    
+    @Published var imageSelection: PhotosPickerItem? = nil {
+        didSet {
+            if let imageSelection {
+                let progress = loadTransferable(from: imageSelection)
+                selectedImageState = .loading(progress)
+            } else {
+                selectedImageState = .empty
+            }
+        }
+    }
+    
+    private func loadTransferable(from imageSelection: PhotosPickerItem) -> Progress {
+        return imageSelection.loadTransferable(type: SelectedImage.self) { result in
+            DispatchQueue.main.async {
+                guard imageSelection == self.imageSelection else {
+                    print("Failed to get the selected image.")
+                    return
+                }
+                switch result {
+                case .success(let selectedImage?):
+                    self.selectedImageState = .success(selectedImage.image)
+                case .success(nil):
+                    self.selectedImageState = .empty
+                case .failure(let error):
+                    self.selectedImageState = .failure(error)
+                }
+            }
+        }
+    }
+}

--- a/Instacard/SelectedImageView.swift
+++ b/Instacard/SelectedImageView.swift
@@ -1,0 +1,52 @@
+//
+//  SelectImageFromAlbumView.swift
+//  Instacard
+//
+//  Created by Nick Kenyeres on 2022-11-04.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct SelectedImage: View {
+    let selectedImageState: SelectedImageModel.SelectedImageState
+    
+    var body: some View {
+        switch selectedImageState {
+        case .success(let image):
+            image.resizable()
+        case .loading:
+            ProgressView()
+                .progressViewStyle(.circular)
+        case .empty:
+            Image(systemName: "photo")
+                .font(.system(size: 80))
+                .foregroundColor(.black)
+        case .failure:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 80))
+                .foregroundColor(.black)
+        }
+    }
+}
+
+struct SelectedImagePreview: View {
+    let selectedImageState: SelectedImageModel.SelectedImageState
+    
+    var body: some View {
+        SelectedImage(selectedImageState: selectedImageState)
+            .scaledToFit()
+            .clipShape(Rectangle())
+    }
+}
+
+struct SelectImageFromAlbum: View {
+    @ObservedObject var viewModel: SelectedImageModel
+    
+    var body: some View {
+        PhotosPicker(selection: $viewModel.imageSelection, matching: .images, photoLibrary: .shared()) {
+            Text("Select Image")
+        }
+        .buttonStyle(.borderless)
+    }
+}


### PR DESCRIPTION
Here is a basic implementation of photo selection to get things started. Apple had some [sample code in their documentation for working with PhotosUI](https://developer.apple.com/documentation/photokit/bringing_photos_picker_to_your_swiftui_app), which I used as the basis for this feature.

The heavy lifting in this feature is implemented within the SelectedImageModel class, which is used to handle selecting a photo from the user's photo album and keep track of whether it is loading, loaded, or failed to load.

The SelectedImageModel class is used as the view model in the main ContentView. I implemented some additional views for working with the view model in SelectedImageView, which include the view for rendering the selected image in its various states, a view for rendering a preview of the selected image, and a button which can be used to open the photo album with selection handled by the view model.

Here's a screenshot of the current blank slate (i.e. no selected photo):

<img width="489" alt="Screenshot 2022-11-04 at 12 21 59 AM" src="https://user-images.githubusercontent.com/431654/199887445-d4d87ce3-8d55-4ee5-aba0-d168f7d4c4cf.png">

Here's a screenshot of a selected photo:

<img width="466" alt="Screenshot 2022-11-04 at 12 22 12 AM" src="https://user-images.githubusercontent.com/431654/199887459-23be4e2a-a805-44cd-bcc0-c955c3d6eaf3.png">
