### PR TITLE
Add support for taking a photo!

### DIFF
--- a/Instacard.xcodeproj/project.pbxproj
+++ b/Instacard.xcodeproj/project.pbxproj
@@ -345,10 +345,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Instacard/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y8N5GH4PJP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Instacard/Info.plist;
+				INFOPLIST_KEY_NSContactsUsageDescription = "Save contacts";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -359,7 +360,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = COSC397Project.Instacard;
+				PRODUCT_BUNDLE_IDENTIFIER = COSC397ProjectMGall.Instacard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -375,10 +376,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Instacard/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y8N5GH4PJP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Instacard/Info.plist;
+				INFOPLIST_KEY_NSContactsUsageDescription = "Save contacts";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Instacard.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Instacard.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>Instacard needs access to your camera to take a photo.</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/Instacard/models/SelectedImageModel.swift
+++ b/Instacard/models/SelectedImageModel.swift
@@ -59,6 +59,18 @@ class SelectedImageModel: ObservableObject {
             }
         }
     }
+    // Michael Gall:
+    // Handles UIImage selection from camera instead of photopicker
+    @Published var uiImageSelection: UIImage? = nil {
+        didSet {
+            if let uiImageSelection {
+                selectedImageState = .success(Image(uiImage: uiImageSelection), uiImageSelection.cgImage!)
+            } else {
+                selectedImageState = .empty
+            }
+        }
+    }
+    
     
     private func loadTransferable(from imageSelection: PhotosPickerItem) -> Progress {
         return imageSelection.loadTransferable(type: SelectedImage.self) { result in

--- a/Instacard/views/SelectImageView.swift
+++ b/Instacard/views/SelectImageView.swift
@@ -10,14 +10,19 @@ import PhotosUI
 
 struct SelectImageView: View {
     @StateObject var viewModel = SelectedImageModel()
+    // "selected" image by camera
+    @State private var image = UIImage()
+    // Whether to show the photo taking view or not
+    @State private var showPhotoTaker = false
     
     var body: some View {
         VStack {
             SelectedImagePreview(selectedImageState: viewModel.selectedImageState)
                 .frame(maxHeight: .infinity)
             VStack {
+                // Taking an image
                 Button {
-                    print("'Take Photo' button clicked")
+                    showPhotoTaker = true
                 } label: {
                     HStack {
                         Image(systemName: "camera")
@@ -27,6 +32,11 @@ struct SelectImageView: View {
                     }
                 }
                 .buttonStyle(.bordered)
+                .sheet(isPresented: $showPhotoTaker) {
+                    SelectImageByTaking(viewModel: viewModel, selectedImage: $image)
+                
+                }
+                // Album images
                 SelectImageFromAlbum(viewModel: viewModel)
             }
         }

--- a/Instacard/views/components/SelectedImage.swift
+++ b/Instacard/views/components/SelectedImage.swift
@@ -115,10 +115,10 @@ struct ImagePicker: UIViewControllerRepresentable {
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
             parent.presentationMode.wrappedValue.dismiss()
             if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                // Add the selected image to the main view model, and update the selection
                 parent.selectedImage = image
+                parent.viewModel.uiImageSelection = image
                 
-                // Access to the image here in parent.selectedImage
-                // TODO: Now that we have the selected UIImage, how do I get it added as a SelectedImageModel to update the main view model?
             }
         }
     }

--- a/Instacard/views/components/SelectedImage.swift
+++ b/Instacard/views/components/SelectedImage.swift
@@ -66,3 +66,62 @@ struct SelectImageFromAlbum: View {
         .buttonStyle(.bordered)
     }
 }
+
+// For taking images, rather than picking from a user's album.
+struct SelectImageByTaking: View {
+    @ObservedObject var viewModel: SelectedImageModel
+    @Binding var selectedImage: UIImage
+    
+    var body: some View {
+        ImagePicker(viewModel: viewModel, selectedImage: self.$selectedImage)
+    }
+}
+
+// Michael Gall:
+// Adapted an "ImagePicker" for taking photos from a camera, based off this.
+// https://designcode.io/swiftui-advanced-handbook-imagepicker
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Environment(\.presentationMode) private var presentationMode
+    @ObservedObject var viewModel: SelectedImageModel
+    @Binding var selectedImage: UIImage
+    var photoSource: UIImagePickerController.SourceType = .camera
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+        
+    }
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    func makeUIViewController(context: UIViewControllerRepresentableContext<ImagePicker>) -> UIImagePickerController {
+        
+        let imagePicker = UIImagePickerController()
+        imagePicker.allowsEditing = false
+        imagePicker.sourceType = photoSource
+        imagePicker.delegate = context.coordinator
+
+        return imagePicker
+    }
+    
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        
+        var parent: ImagePicker
+        
+        init(_ parent: ImagePicker) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            parent.presentationMode.wrappedValue.dismiss()
+            if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                parent.selectedImage = image
+                
+                // Access to the image here in parent.selectedImage
+                // TODO: Now that we have the selected UIImage, how do I get it added as a SelectedImageModel to update the main view model?
+            }
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
To take a photo, I used an example from online for creating an image picker that only loads from the camera. 

https://designcode.io/swiftui-advanced-handbook-imagepicker

From here, I added the ability to select the view model's image off a UIImage and not a PhotoPickerItem. Then, whenever a photo is taken and approved by the user, it'll update the SelectedImageModel in the main view with the selected UIImage. This works just like a PhotoPickerItem sourced image for extraction.. 